### PR TITLE
Load with generic interfaces

### DIFF
--- a/evtx/evtx.go
+++ b/evtx/evtx.go
@@ -66,8 +66,8 @@ type File struct {
 	monitorExisting bool
 }
 
-// New EvtxFile structure initialized from file
-// @filepath : filepath of the evtx file to parse
+// New EvtxFile structure initialized from an open buffer
+// @r : buffer containing evtx data to parse
 // return File : File structure initialized
 func New(r io.ReadSeeker) (ef File, err error) {
 	ef.file = r
@@ -76,7 +76,9 @@ func New(r io.ReadSeeker) (ef File, err error) {
 	return
 }
 
-// Open alias to New to be complient with the Go way of programming
+// New EvtxFile structure initialized from file
+// @filepath : filepath of the evtx file to parse
+// return File : File structure initialized
 func Open(filepath string) (ef File, err error) {
 	file, err := os.Open(filepath)
 	if err != nil {

--- a/evtx/structs.go
+++ b/evtx/structs.go
@@ -426,9 +426,13 @@ func (uts *UnicodeTextString) Parse(reader io.ReadSeeker) error {
 	if err != nil {
 		return err
 	}
-	uts.String = make(UTF16String, uts.Size)
-	err = encoding.UnmarshaInitSlice(reader, &uts.String, Endianness)
-	//log.Debugf("len:%d value:%s", uts.Size, string(uts.String.ToASCII()))
+
+	if uts.Size > 0 {
+		uts.String = make(UTF16String, uts.Size)
+		err = encoding.UnmarshaInitSlice(reader, &uts.String, Endianness)
+		//log.Debugf("len:%d value:%s", uts.Size, string(uts.String.ToASCII()))
+	}
+
 	return err
 }
 

--- a/evtx/test/evtx_test.go
+++ b/evtx/test/evtx_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/0xrawsec/golang-utils/log"
 	"github.com/0xrawsec/golang-evtx/evtx"
+	"github.com/0xrawsec/golang-utils/log"
 )
 
 var (
@@ -34,7 +34,7 @@ func init() {
 }
 
 func TestParseAt(t *testing.T) {
-	ef, _ := evtx.New(sysmonFile)
+	ef, _ := evtx.Open(sysmonFile)
 	offsetChunk := 0x033c1000
 	offsetElt := 0x21c
 
@@ -57,7 +57,7 @@ func TestParseAt(t *testing.T) {
 }
 
 func TestNodeTree(t *testing.T) {
-	ef, _ := evtx.New(evtxFile)
+	ef, _ := evtx.Open(evtxFile)
 	offsetChunk := 0x00251000
 	offsetElt := 1852
 
@@ -95,7 +95,7 @@ func TestNodeTree(t *testing.T) {
 }
 
 func TestParseOneChunk(t *testing.T) {
-	ef, _ := evtx.New(forwardedEvtxFile)
+	ef, _ := evtx.Open(forwardedEvtxFile)
 	offsetChunk := int64(0x016e1000)
 	c, err := ef.FetchChunk(offsetChunk)
 	if err != nil && err != io.EOF {
@@ -109,7 +109,7 @@ func TestParseOneChunk(t *testing.T) {
 }
 
 func TestParseEventAt(t *testing.T) {
-	ef, _ := evtx.New(forwardedEvtxFile)
+	ef, _ := evtx.Open(forwardedEvtxFile)
 	offsetChunk := 0x016e1000
 	offsetEvent := 0x016ef748 - offsetChunk
 	c, err := ef.FetchChunk(int64(offsetChunk))
@@ -127,7 +127,7 @@ func TestParseEventAt(t *testing.T) {
 func TestParseEventByID(t *testing.T) {
 	filepath := appReadyFile
 	t.Logf("Parsing: %s ", filepath)
-	ef, _ := evtx.New(filepath)
+	ef, _ := evtx.Open(filepath)
 	eventRecordID := int64(1448)
 loop:
 	for c := range ef.Chunks() {
@@ -147,7 +147,7 @@ loop:
 func TestParseAllEvents(t *testing.T) {
 	maxChunks := 1000
 	chunkCount := 0
-	ef, _ := evtx.New(forwardedEvtxFile)
+	ef, _ := evtx.Open(forwardedEvtxFile)
 	log.Info(ef.Header)
 	for c := range ef.Chunks() {
 		//log.Info(c.Header)
@@ -165,14 +165,14 @@ func TestParseChunk(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping in short test")
 	}
-	ef, _ := evtx.New(sysmonFile)
+	ef, _ := evtx.Open(sysmonFile)
 	for e := range ef.FastEvents() {
 		t.Log(string(evtx.ToJSON(e)))
 	}
 }
 
 /*func TestMonitorChunks(t *testing.T) {
-	ef, _ := evtx.New(sysmonFile)
+	ef, _ := evtx.Open(sysmonFile)
 	stop := make(chan bool, 1)
 	go func() {
 		time.Sleep(time.Second * 10)
@@ -184,7 +184,7 @@ func TestParseChunk(t *testing.T) {
 }*/
 
 func TestRightOrderSlowEvents(t *testing.T) {
-	ef, _ := evtx.New(sysmonFile)
+	ef, _ := evtx.Open(sysmonFile)
 	i := 0
 	prevErid := uint64(0)
 	sPath := evtx.Path("/Event/System/EventRecordID/Value")
@@ -203,7 +203,7 @@ func TestRightOrderSlowEvents(t *testing.T) {
 }
 
 func TestRightOrderFastEvents(t *testing.T) {
-	ef, _ := evtx.New(sysmonFile)
+	ef, _ := evtx.Open(sysmonFile)
 	prevErid := int64(0)
 	i := 0
 	for e := range ef.FastEvents() {
@@ -221,7 +221,7 @@ func TestRightOrderFastEvents(t *testing.T) {
 }
 
 func TestFilter(t *testing.T) {
-	ef, _ := evtx.New(sysmonFile)
+	ef, _ := evtx.Open(sysmonFile)
 	p := evtx.Path("/Event/EventData/Data1/Value")
 	for e := range ef.FastEvents() {
 		if e.Equal(&p, "B2796A13-E43D-5880-0000-0010C55A0F00") {
@@ -232,7 +232,7 @@ func TestFilter(t *testing.T) {
 }
 
 func TestEventIDFilter(t *testing.T) {
-	ef, _ := evtx.New(sysmonFile)
+	ef, _ := evtx.Open(sysmonFile)
 	for e := range ef.FastEvents() {
 		if e.IsEventID("1", "12") {
 			t.Log(string(evtx.ToJSON(e)))
@@ -242,7 +242,7 @@ func TestEventIDFilter(t *testing.T) {
 
 func TestPatternFilter(t *testing.T) {
 	pattern := regexp.MustCompile("MD5=D81F3ABB789C1D4504203171467A5E4E")
-	ef, _ := evtx.New(sysmonFile)
+	ef, _ := evtx.Open(sysmonFile)
 	p := evtx.Path("/Event/EventData/Data11/Value")
 	for e := range ef.FastEvents() {
 		if e.RegexMatch(&p, pattern) {
@@ -253,7 +253,7 @@ func TestPatternFilter(t *testing.T) {
 }
 
 func TestMapFilter(t *testing.T) {
-	ef, _ := evtx.New(sysmonFile)
+	ef, _ := evtx.Open(sysmonFile)
 	p := evtx.Path("/Event/EventData/Data11/Name")
 	for e := range ef.FastEvents() {
 		m, err := e.GetMap(&p)
@@ -265,7 +265,7 @@ func TestMapFilter(t *testing.T) {
 }
 
 func TestMapWhereFilter(t *testing.T) {
-	ef, _ := evtx.New(sysmonFile)
+	ef, _ := evtx.Open(sysmonFile)
 	p := evtx.Path("/Event/EventData/Data1/Name")
 	for e := range ef.FastEvents() {
 		m, err := e.GetMapWhere(&p, "SourceProcessGUID")
@@ -278,7 +278,7 @@ func TestMapWhereFilter(t *testing.T) {
 
 func TestBetweenFilter(t *testing.T) {
 	i := 0
-	ef, _ := evtx.New(sysmonFile)
+	ef, _ := evtx.Open(sysmonFile)
 	t1, err := time.Parse(time.RFC3339, "2017-01-19T17:07:20+01:00")
 	if err != nil {
 		panic(err)
@@ -304,7 +304,7 @@ func TestAllFiles(t *testing.T) {
 	for _, fi := range files {
 		fullpath := filepath.Join(testfilesDir, fi.Name())
 		t.Logf("Parsing : %s", fullpath)
-		ef, _ := evtx.New(fullpath)
+		ef, _ := evtx.Open(fullpath)
 		for _ = range ef.FastEvents() {
 		}
 	}
@@ -317,7 +317,7 @@ func TestUserID(t *testing.T) {
 	}
 	for _, fi := range files {
 		fullpath := filepath.Join(testfilesDir, fi.Name())
-		ef, _ := evtx.New(fullpath)
+		ef, _ := evtx.Open(fullpath)
 		for e := range ef.FastEvents() {
 			if uid, ok := e.UserID(); ok {
 				if uid == "" {

--- a/tools/evtxdump/evtxdump.go
+++ b/tools/evtxdump/evtxdump.go
@@ -345,7 +345,7 @@ func main() {
 		}
 		if !carve {
 			// Regular EVTX file
-			ef, err := evtx.New(evtxFile)
+			ef, err := evtx.Open(evtxFile)
 			if err != nil {
 				log.Error(err)
 				continue

--- a/tools/evtxmon/evtxmon.go
+++ b/tools/evtxmon/evtxmon.go
@@ -226,7 +226,7 @@ func main() {
 		os.Exit(1)
 	} else {
 		stop := make(chan bool, 1)
-		ef, err := evtx.New(evtxfile)
+		ef, err := evtx.Open(evtxfile)
 		if err != nil {
 			log.LogErrorAndExit(err)
 		}


### PR DESCRIPTION
This updates the interface for loading EVTX data to be more idiomatic by accepting a generic `io.ReadSeeker` when calling `evtx.New()`. This makes it possible to bypass the dependency on a filesystem by default, while still providing the `evtx.Open()` function when loading from a filesystem is desirable.