### PR TITLE
change Events() to have same behavior as FastEvents()

### DIFF
--- a/evtx/evtx.go
+++ b/evtx/evtx.go
@@ -373,7 +373,11 @@ func (ef *File) Events() (cgem chan *GoEvtxMap) {
 	go func() {
 		defer close(cgem)
 		for c := range ef.Chunks() {
-			for e := range c.Events() {
+			cpc, err := ef.FetchChunk(c.Offset)
+			if err != nil {
+				panic(err)
+			}
+			for e := range cpc.Events() {
 				cgem <- e
 			}
 		}


### PR DESCRIPTION
Fix for #23. Following the same pattern as `FastEvents()` does for this fix. `Events()` still panics on error like `FastEvents()` and should be functionally equivalent.  