### PR TITLE
attempt at fixing data race in #25

### DIFF
--- a/evtx/globals.go
+++ b/evtx/globals.go
@@ -73,7 +73,7 @@ const (
 var (
 	Endianness = binary.LittleEndian
 	// Used for debug purposes
-	lastParsedElements [4]Element
+	lastParsedElements = &LastParsedElements{elements: [4]Element{}}
 )
 
 //////////////////////////////// BinXMLTokens //////////////////////////////////

--- a/evtx/utils.go
+++ b/evtx/utils.go
@@ -78,8 +78,8 @@ func DebugReader(reader io.ReadSeeker, before, after int64) {
 }
 
 func UpdateLastElements(e Element) {
-	copy(lastParsedElements[:], lastParsedElements[1:])
-	lastParsedElements[len(lastParsedElements)-1] = e
+	// copy(lastParsedElements[:], lastParsedElements[1:])
+	// lastParsedElements[len(lastParsedElements)-1] = e
 }
 
 func BackupSeeker(seeker io.Seeker) int64 {


### PR DESCRIPTION
`go build -race tools/evtxdump/... && ./evtxdump -s $EVTX_FILE` produces a race warning. It was observed that the data race could reside here:
https://github.com/0xrawsec/golang-evtx/blob/fb1efdb926d27bb62f9b82f532fdd6a66fa14741/evtx/utils.go#L80-L83
 This is most likely due to the fact that multiple goroutines are attempting to alter the global array `lastParsedElements`. After commenting out the function body of `UpdateLastElements` and rerunning the same commands mentioned above, there is no longer a race condition warning.

I'm not aware of the purpose of `lastParsedElements`. However, the comment for the variable mentions that it is for debug purposes so I assume that the impact of commenting out the code in `UpdateLastElements` to be small.